### PR TITLE
Add initial test suite (19 tests) and upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>6.0.0</version>
+            <version>6.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.univocity</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>com.atomgraph.etl.csv</groupId>
     <artifactId>csv2rdf</artifactId>
-    <version>2.1.12-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <name>CSV2RDF</name>
@@ -42,6 +42,18 @@
     
     <dependencies>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.14.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.36</version>
@@ -49,7 +61,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>4.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.univocity</groupId>
@@ -60,7 +72,7 @@
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
-            <version>4.0.4</version>
+            <version>4.7.7</version>
         </dependency>
     </dependencies>
     
@@ -69,8 +81,13 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.0</version>
+                <version>3.14.1</version>
                 <configuration>
                     <release>17</release>
                 </configuration>
@@ -78,7 +95,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.3.1</version>
                 <configuration>
                     <releaseProfiles>release</releaseProfiles>
                 </configuration>
@@ -112,21 +129,21 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.12.0</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <excludePackageNames>*.impl</excludePackageNames>
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.12</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.9.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central-portal-snapshots</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
         </plugins>
@@ -134,8 +151,8 @@
     
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central-portal-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
     
@@ -147,7 +164,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>3.4.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -160,7 +177,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.1.1</version>
+                        <version>3.12.0</version>
                         <configuration>
                             <encoding>UTF-8</encoding>
                             <excludePackageNames>*.impl</excludePackageNames>

--- a/src/test/java/com/atomgraph/etl/csv/ModelTransformerTest.java
+++ b/src/test/java/com/atomgraph/etl/csv/ModelTransformerTest.java
@@ -1,0 +1,85 @@
+/**
+ *  Copyright 2026 Martynas Jusevičius <martynas@atomgraph.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.atomgraph.etl.csv;
+
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ModelTransformerTest
+{
+
+    private final ModelTransformer transformer = new ModelTransformer();
+
+    @Test
+    void applyIdentityConstructReturnsIsomorphicModel()
+    {
+        Model input = ModelFactory.createDefaultModel();
+        input.add(
+            input.createResource("http://example.com/s"),
+            RDF.type,
+            input.createResource("http://example.com/Type")
+        );
+
+        Query query = QueryFactory.create("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }");
+        Model result = transformer.apply(query, input);
+
+        assertTrue(result.isIsomorphicWith(input));
+    }
+
+    @Test
+    void applyEmptyInputReturnsEmptyModel()
+    {
+        Model input = ModelFactory.createDefaultModel();
+        Query query = QueryFactory.create("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }");
+
+        Model result = transformer.apply(query, input);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void applyFilteringConstructReturnsSubset()
+    {
+        Model input = ModelFactory.createDefaultModel();
+        input.add(
+            input.createResource("http://example.com/s"),
+            input.createProperty("http://example.com/#name"),
+            "Alice"
+        );
+        input.add(
+            input.createResource("http://example.com/s"),
+            input.createProperty("http://example.com/#age"),
+            "30"
+        );
+
+        // Only map name, not age
+        Query query = QueryFactory.create(
+            "PREFIX ex: <http://example.com/#> " +
+            "CONSTRUCT { ?s ex:name ?name } WHERE { ?s ex:name ?name }"
+        );
+        Model result = transformer.apply(query, input);
+
+        assertEquals(1, result.size());
+    }
+
+}

--- a/src/test/java/com/atomgraph/etl/csv/stream/CSVStreamRDFOutputTest.java
+++ b/src/test/java/com/atomgraph/etl/csv/stream/CSVStreamRDFOutputTest.java
@@ -1,0 +1,93 @@
+/**
+ *  Copyright 2026 Martynas Jusevičius <martynas@atomgraph.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.atomgraph.etl.csv.stream;
+
+import com.univocity.parsers.common.TextParsingException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CSVStreamRDFOutputTest
+{
+
+    private static final String BASE = "http://example.com/";
+    private static final Query IDENTITY_QUERY = QueryFactory.create("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }");
+
+    @Test
+    void writeProducesNonEmptyRDFOutput()
+    {
+        String csv = "name,age\nAlice,30\nBob,25\n";
+        CSVStreamRDFOutput output = new CSVStreamRDFOutput(new StringReader(csv), BASE, IDENTITY_QUERY, ',', null);
+
+        StringWriter writer = new StringWriter();
+        output.write(writer);
+
+        assertFalse(writer.toString().isBlank());
+    }
+
+    @Test
+    void writeWithCustomDelimiterParsesCorrectly()
+    {
+        String csv = "name;age\nAlice;30\n";
+        CSVStreamRDFOutput output = new CSVStreamRDFOutput(new StringReader(csv), BASE, IDENTITY_QUERY, ';', null);
+
+        output.write(new StringWriter());
+
+        assertEquals(1, output.getCSVStreamRDFProcessor().getSubjectCount());
+        assertEquals(2, output.getCSVStreamRDFProcessor().getTripleCount());
+    }
+
+    @Test
+    void writeTwoRowsCountsSubjectsCorrectly()
+    {
+        String csv = "name,age\nAlice,30\nBob,25\n";
+        CSVStreamRDFOutput output = new CSVStreamRDFOutput(new StringReader(csv), BASE, IDENTITY_QUERY, ',', null);
+
+        output.write(new StringWriter());
+
+        assertEquals(2, output.getCSVStreamRDFProcessor().getSubjectCount());
+        assertEquals(4, output.getCSVStreamRDFProcessor().getTripleCount());
+    }
+
+    @Test
+    void headerOnlyProducesEmptyOutput()
+    {
+        String csv = "name,age\n";
+        CSVStreamRDFOutput output = new CSVStreamRDFOutput(new StringReader(csv), BASE, IDENTITY_QUERY, ',', null);
+
+        output.write(new StringWriter());
+
+        assertEquals(0, output.getCSVStreamRDFProcessor().getSubjectCount());
+        assertEquals(0, output.getCSVStreamRDFProcessor().getTripleCount());
+    }
+
+    @Test
+    void maxCharsPerColumnThrowsOnLongValue()
+    {
+        // "name" header (4 chars) fits within maxCharsPerColumn=5;
+        // the data value "Hello World" (11 chars) exceeds it and must cause a TextParsingException
+        String csv = "name\nHello World\n";
+        CSVStreamRDFOutput output = new CSVStreamRDFOutput(new StringReader(csv), BASE, IDENTITY_QUERY, ',', 5);
+
+        assertThrows(TextParsingException.class, () -> output.write(new StringWriter()));
+    }
+
+}

--- a/src/test/java/com/atomgraph/etl/csv/stream/CSVStreamRDFProcessorTest.java
+++ b/src/test/java/com/atomgraph/etl/csv/stream/CSVStreamRDFProcessorTest.java
@@ -1,0 +1,204 @@
+/**
+ *  Copyright 2026 Martynas Jusevičius <martynas@atomgraph.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.atomgraph.etl.csv.stream;
+
+import com.univocity.parsers.common.ParsingContext;
+import java.io.StringWriter;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.riot.system.StreamRDF;
+import org.apache.jena.riot.system.StreamRDFLib;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CSVStreamRDFProcessorTest
+{
+
+    private static final String BASE = "http://example.com/";
+    private static final Query IDENTITY_QUERY = QueryFactory.create("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }");
+
+    @Mock
+    private ParsingContext context;
+
+    private final StreamRDF stream = StreamRDFLib.writer(new StringWriter());
+
+    @Test
+    void constructorRejectsSelectQuery()
+    {
+        Query selectQuery = QueryFactory.create("SELECT * WHERE { ?s ?p ?o }");
+        assertThrows(IllegalArgumentException.class, () -> new CSVStreamRDFProcessor(stream, BASE, selectQuery));
+    }
+
+    @Test
+    void transformRowCreatesTriples()
+    {
+        when(context.headers()).thenReturn(new String[]{"name", "age"});
+
+        CSVStreamRDFProcessor processor = new CSVStreamRDFProcessor(stream, BASE, IDENTITY_QUERY);
+        processor.processStarted(context);
+
+        Model result = processor.transformRow(new String[]{"Alice", "30"}, context);
+
+        assertEquals(2, result.size());
+        assertEquals(1, processor.getSubjectCount());
+        assertEquals(2, processor.getTripleCount());
+    }
+
+    @Test
+    void transformRowSkipsNullCells()
+    {
+        when(context.headers()).thenReturn(new String[]{"name", "age"});
+
+        CSVStreamRDFProcessor processor = new CSVStreamRDFProcessor(stream, BASE, IDENTITY_QUERY);
+        processor.processStarted(context);
+
+        Model result = processor.transformRow(new String[]{null, "30"}, context);
+
+        assertEquals(1, result.size());
+        assertEquals(1, processor.getTripleCount());
+    }
+
+    @Test
+    void transformRowSkipsNullHeader()
+    {
+        when(context.headers()).thenReturn(new String[]{"name", null});
+
+        CSVStreamRDFProcessor processor = new CSVStreamRDFProcessor(stream, BASE, IDENTITY_QUERY);
+        processor.processStarted(context);
+
+        Model result = processor.transformRow(new String[]{"Alice", "30"}, context);
+
+        assertEquals(1, result.size());
+        assertEquals(1, processor.getTripleCount());
+    }
+
+    @Test
+    void processStartedResetsCounters()
+    {
+        when(context.headers()).thenReturn(new String[]{"name"});
+
+        CSVStreamRDFProcessor processor = new CSVStreamRDFProcessor(stream, BASE, IDENTITY_QUERY);
+        processor.processStarted(context);
+        processor.transformRow(new String[]{"Alice"}, context);
+        assertEquals(1, processor.getSubjectCount());
+
+        processor.processStarted(context);
+        assertEquals(0, processor.getSubjectCount());
+        assertEquals(0, processor.getTripleCount());
+    }
+
+    @Test
+    void propertyIriUsesBaseAndEncodedHeader()
+    {
+        when(context.headers()).thenReturn(new String[]{"name"});
+
+        CSVStreamRDFProcessor processor = new CSVStreamRDFProcessor(stream, BASE, IDENTITY_QUERY);
+        processor.processStarted(context);
+
+        Model result = processor.transformRow(new String[]{"Alice"}, context);
+
+        Statement stmt = result.listStatements().nextStatement();
+        assertEquals("http://example.com/#name", stmt.getPredicate().getURI());
+    }
+
+    @Test
+    void headerWithSpacesIsPercentEncoded()
+    {
+        when(context.headers()).thenReturn(new String[]{"first name"});
+
+        CSVStreamRDFProcessor processor = new CSVStreamRDFProcessor(stream, BASE, IDENTITY_QUERY);
+        processor.processStarted(context);
+
+        Model result = processor.transformRow(new String[]{"Alice"}, context);
+
+        Statement stmt = result.listStatements().nextStatement();
+        assertTrue(stmt.getPredicate().getURI().contains("first%20name"));
+    }
+
+    @Test
+    void headerWithHashIsPercentEncoded()
+    {
+        when(context.headers()).thenReturn(new String[]{"#col"});
+
+        CSVStreamRDFProcessor processor = new CSVStreamRDFProcessor(stream, BASE, IDENTITY_QUERY);
+        processor.processStarted(context);
+
+        Model result = processor.transformRow(new String[]{"val"}, context);
+
+        Statement stmt = result.listStatements().nextStatement();
+        assertTrue(stmt.getPredicate().getURI().contains("%23col"));
+    }
+
+    @Test
+    void headerWithSlashIsPercentEncoded()
+    {
+        when(context.headers()).thenReturn(new String[]{"a/b"});
+
+        CSVStreamRDFProcessor processor = new CSVStreamRDFProcessor(stream, BASE, IDENTITY_QUERY);
+        processor.processStarted(context);
+
+        Model result = processor.transformRow(new String[]{"val"}, context);
+
+        Statement stmt = result.listStatements().nextStatement();
+        assertTrue(stmt.getPredicate().getURI().contains("a%2Fb"));
+    }
+
+    @Test
+    void cellValueIsPlainStringLiteral()
+    {
+        when(context.headers()).thenReturn(new String[]{"name"});
+
+        CSVStreamRDFProcessor processor = new CSVStreamRDFProcessor(stream, BASE, IDENTITY_QUERY);
+        processor.processStarted(context);
+
+        Model result = processor.transformRow(new String[]{"Alice"}, context);
+
+        Literal lit = result.listStatements().nextStatement().getLiteral();
+        assertEquals("Alice", lit.getString());
+        assertTrue(lit.getLanguage().isEmpty());
+        assertTrue(lit.getDatatypeURI() == null
+            || lit.getDatatypeURI().equals(XSDDatatype.XSDstring.getURI()));
+    }
+
+    @Test
+    void numericCellIsStillStringLiteral()
+    {
+        when(context.headers()).thenReturn(new String[]{"age"});
+
+        CSVStreamRDFProcessor processor = new CSVStreamRDFProcessor(stream, BASE, IDENTITY_QUERY);
+        processor.processStarted(context);
+
+        Model result = processor.transformRow(new String[]{"42"}, context);
+
+        Literal lit = result.listStatements().nextStatement().getLiteral();
+        assertEquals("42", lit.getString());
+        assertTrue(lit.getLanguage().isEmpty());
+        assertTrue(lit.getDatatypeURI() == null
+            || lit.getDatatypeURI().equals(XSDDatatype.XSDstring.getURI()));
+    }
+
+}


### PR DESCRIPTION
Adds `CSVStreamRDFProcessorTest` and `CSVStreamRDFOutputTest` covering IRI percent-encoding, literal datatypes, null cell/header skipping, counter resets, delimiter handling, and `maxCharsPerColumn` enforcement.

Also upgrades Jena to 6.0.0, picocli to 4.7.7, and various Maven plugin versions; adds JUnit Jupiter 5.11.4 and Mockito 5.14.2 test dependencies; migrates publishing from nexus-staging to central-publishing-maven-plugin.